### PR TITLE
readme - correct some small cosmetic typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Love Streamlit but:
 - impossible to customise beyond PoC phase
 - overly complicated
 
-H-(html)-Stream stream is built with semantic html, FastApi and htmx to provide a fast and simple framework for rapid web app developmenet that follows traditional frontend/server architecture (or atleast follow it closer than Streamlit).
+H-(html)-Stream stream is built with semantic html, FastApi and htmx to provide a fast and simple framework for rapid web app development that follows traditional frontend/server architecture (or at least follow it closer than Streamlit).
 
 # Features
 
@@ -55,12 +55,12 @@ H-(html)-Stream stream is built with semantic html, FastApi and htmx to provide 
 
 `hs.html`: allows more complex formatting, for example 
 
-`hs.stylesheet_href = https://unpkg.com/@vladocar/basic.css@1.0.3/css/basic.css` to use a diffrent classless css framework
+`hs.stylesheet_href = https://unpkg.com/@vladocar/basic.css@1.0.3/css/basic.css` to use a different classless css framework
 
 ```
 with hs.html('form'):
     hs.text_input('Name'):
-    hs.checkbox('Would you like to be my firend?')
+    hs.checkbox('Would you like to be my friend?')
 ```
 
 # Technologies


### PR DESCRIPTION
some small tweaks fixing typos in the readme


also considered but wanted your thoughts before changing:
- classless -> class-less
- uvicorn -> unicorn ?